### PR TITLE
Add capture data functionality in the SME samples + fix create compon…

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This repository contains the following examples of components.
 - mqtt-bridge - This component bridges a local MQTT Broker to the AWS IoT Core broker by automatically forwarding
  messages between the device and cloud on specified topics.
 
+- machine-learning/sagemaker-edge-manager - These components serve as samples to run image classification and object detection inferences on edge using aws.greengrass.SageMakerEdgeManager component. 
+
 ## License
 
 These examples are licensed under the Apache 2.0 License. 

--- a/machine-learning/sagemaker-edge-manager/README.md
+++ b/machine-learning/sagemaker-edge-manager/README.md
@@ -40,14 +40,21 @@ Follow the steps in order to prepare the component artifacts, recipes and create
         The above command uses **us-east-1**(default) region to create **Image Classification** example components and **ggv2-example-component-artifacts-us-east-1**(default) bucket to store the component artifacts. 
     
     
-    - To specify desired region, bucket and inference type, use the following command(region name is appended to the bucket name) 
+    - To specify desired region, bucket and inference type, use the following command (region name is appended to the bucket name) 
 
         `python3 create_components.py -r region -b bucket -i inferenceType`
+
+    - To create a specific component, provide the script with the name of the component using `componentName` argument as shown below. 
+
+        `python3 create_components.py -c componentName` 
 
         ```
         region - Region where you want to create and use the greengrass components.
         bucket - Name of the bucket which is used to store the component artifacts.
         inferenceType - Type of the inference. Values: ImageClassification / ObjectDetection. 
+        componentType - Name of the component to create.
+
+        Note: Inference type and component type args are mutually exclusive. 
         ```
     - This script creates a build folder with the prepared artifacts and upload them to the s3 bucket. The sample models are downloaded from the releases section based on the parameters like region and inference type. This might take several minutes as the artifacts are prepared and uploaded to the desired S3 bucket. 
 
@@ -57,7 +64,7 @@ Follow the steps in order to prepare the component artifacts, recipes and create
 ----
 ## Deploy components
 
-Follow the documentation at [Link](Link-to-the-documentation) to deploy the inference and model components to run the inference. 
+Follow the [documentation](https://docs.aws.amazon.com/greengrass/v2/developerguide/get-started-with-edge-manager-on-greengrass.html#run-sample-sme-image-classification-inference) to deploy inference and model components and run inference on the edge using sagemaker edge manager. 
 
 
 

--- a/machine-learning/sagemaker-edge-manager/artifacts/com.greengrass.SageMakerEdgeManager.ImageClassification/1.0.0/image_classification/inference.py
+++ b/machine-learning/sagemaker-edge-manager/artifacts/com.greengrass.SageMakerEdgeManager.ImageClassification/1.0.0/image_classification/inference.py
@@ -100,7 +100,12 @@ def run_inference(new_config, config_changed):
         if config_utils.SCHEDULED_THREAD is not None:
             config_utils.SCHEDULED_THREAD.cancel()
             config_changed = False
-    predict_from_image(new_config["image"])
+    try:
+        predict_from_image(new_config["image"])
+    except Exception as e:
+        config_utils.logger.error(
+            "Error running the inference as the edge agent config changed: {}".format(e)
+        )
     config_utils.SCHEDULED_THREAD = Timer(
         int(new_config["prediction_interval_secs"]),
         run_inference,

--- a/machine-learning/sagemaker-edge-manager/artifacts/com.greengrass.SageMakerEdgeManager.ObjectDetection/1.0.0/object_detection/inference.py
+++ b/machine-learning/sagemaker-edge-manager/artifacts/com.greengrass.SageMakerEdgeManager.ObjectDetection/1.0.0/object_detection/inference.py
@@ -107,7 +107,12 @@ def run_inference(new_config, config_changed):
         if config_utils.SCHEDULED_THREAD is not None:
             config_utils.SCHEDULED_THREAD.cancel()
         config_changed = False
-    predict_from_image(new_config["image"])
+    try:
+        predict_from_image(new_config["image"])
+    except Exception as e:
+        config_utils.logger.error(
+            "Error running the inference as the edge agent config changed: {}".format(e)
+        )
     config_utils.SCHEDULED_THREAD = Timer(
         int(new_config["prediction_interval_secs"]),
         run_inference,

--- a/machine-learning/sagemaker-edge-manager/artifacts/com.greengrass.SageMakerEdgeManager.ObjectDetection/1.0.0/object_detection/prediction_utils.py
+++ b/machine-learning/sagemaker-edge-manager/artifacts/com.greengrass.SageMakerEdgeManager.ObjectDetection/1.0.0/object_detection/prediction_utils.py
@@ -1,6 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import uuid
 from ast import literal_eval
 from datetime import datetime, timezone
 from json import dumps
@@ -10,6 +11,7 @@ import cv2
 import IPCUtils as ipc_utils
 import numpy as np
 from agent_pb2 import (
+    CaptureDataRequest,
     ListModelsRequest,
     LoadModelRequest,
     PredictRequest,
@@ -122,25 +124,27 @@ def predict(image_data):
         config_utils.MAX_NO_OF_RESULTS, config_utils.SCORE_THRESHOLD
     )
     PAYLOAD["inference-results"] = []
-
+    input_tensors = [
+        Tensor(
+            tensor_metadata=TensorMetadata(
+                name=config_utils.tensor_name,
+                data_type=5,
+                shape=config_utils.tensor_shape,
+            ),
+            byte_data=image_data.tobytes(),
+        )
+    ]
     request = PredictRequest(
         name=config_utils.MODEL_NAME,
-        tensors=[
-            Tensor(
-                tensor_metadata=TensorMetadata(
-                    name=config_utils.tensor_name,
-                    data_type=5,
-                    shape=config_utils.tensor_shape,
-                ),
-                byte_data=image_data.tobytes(),
-            )
-        ],
+        tensors=input_tensors,
     )
     response = config_utils.agent_client.Predict(request)
+    output_tensors = response.tensors
+    capture_data(input_tensors, output_tensors)
 
     detections = []
 
-    for t in response.tensors:
+    for t in output_tensors:
         deserialized_bytes = np.frombuffer(t.byte_data, dtype=np.float32)
         detections.append(np.asarray(deserialized_bytes).tolist())
 
@@ -170,3 +174,16 @@ def predict(image_data):
         ipc_utils.IPCUtils().publish_results_to_cloud(PAYLOAD)
     else:
         config_utils.logger.warn("No topic set to publish the inference results to the cloud.")
+
+
+def capture_data(input_tensors, output_tensors):
+    capture_id = uuid.uuid4()
+    capture_data_request = CaptureDataRequest(
+        model_name=config_utils.MODEL_NAME,
+        capture_id=str(capture_id),
+        input_tensors=input_tensors,
+        output_tensors=output_tensors,
+    )
+    config_utils.logger.info("Capturing the data...")
+    capture_data_response = config_utils.agent_client.CaptureData(capture_data_request)
+    config_utils.logger.info(capture_data_response)

--- a/machine-learning/sagemaker-edge-manager/recipes/com.greengrass.SageMakerEdgeManager.ImageClassification-1.0.0.json
+++ b/machine-learning/sagemaker-edge-manager/recipes/com.greengrass.SageMakerEdgeManager.ImageClassification-1.0.0.json
@@ -11,7 +11,7 @@
                     "com.greengrass.SageMakerEdgeManager.ImageClassification:mqttproxy:1": {
                         "policyDescription": "Allows access to publish via topic gg/sageMakerEdgeManager/image-classification.",
                         "operations": [
-                            "com.greengrass#PublishToIoTCore"
+                            "aws.greengrass#PublishToIoTCore"
                         ],
                         "resources": [
                             "gg/sageMakerEdgeManager/image-classification"

--- a/machine-learning/sagemaker-edge-manager/recipes/com.greengrass.SageMakerEdgeManager.ObjectDetection-1.0.0.json
+++ b/machine-learning/sagemaker-edge-manager/recipes/com.greengrass.SageMakerEdgeManager.ObjectDetection-1.0.0.json
@@ -11,7 +11,7 @@
                     "com.greengrass.SageMakerEdgeManager.ObjectDetection:mqttproxy:1": {
                         "policyDescription": "Allows access to publish via topic gg/sageMakerEdgeManager/object-detection.",
                         "operations": [
-                            "com.greengrass#PublishToIoTCore"
+                            "aws.greengrass#PublishToIoTCore"
                         ],
                         "resources": [
                             "gg/sageMakerEdgeManager/object-detection"


### PR DESCRIPTION
…ents script

**Issue #, if available:**

- These samples now use CaptureData api to capture the input and output tensors with every inference run and upload them to Cloud or store on disk based on the config set in the aws.greengrass.SageMakerEdgeManager component.  
- Add `--componentName/-c` argument to create a specific component using create_components.py script.  Also, fix bugs in the script. 
- Fix config in the inference component recipes. 

**Description of changes:**

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
