### PR TITLE
Add configuration option to disable install script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ target/
 *.jar
 .DS_Store
 build/
+*.idea

--- a/machine-learning/lambda-v2/artifacts/com.lambda.DLR/1.6.0/installer/installer.sh
+++ b/machine-learning/lambda-v2/artifacts/com.lambda.DLR/1.6.0/installer/installer.sh
@@ -6,6 +6,27 @@
 
 set -eux
 
+while getopts ":i:" opt; do
+  case ${opt} in
+    i )
+      use_installer=$OPTARG
+      ;;
+    \? )
+      echo "Invalid option: $OPTARG" 1>&2
+      exit;;
+    : )
+      echo "Invalid option: $OPTARG requires an argument" 1>&2
+      exit;;
+  esac
+done
+
+if [ "$use_installer" = true ]; then
+  echo "Running DLR install script...";
+else
+  echo "Skipping installation of component dependencies.";
+  exit 0;
+fi
+
 kernel=$(uname -s)
 dlr_version="1.6.0"
 min_py_version="3.0.0"

--- a/machine-learning/lambda-v2/artifacts/com.lambda.DLR/1.6.0/installer/utils.sh
+++ b/machine-learning/lambda-v2/artifacts/com.lambda.DLR/1.6.0/installer/utils.sh
@@ -32,6 +32,7 @@ get_awsiotsdk_command=$(
     cat <<END
 try:
     import awsiot
+    print(awsiot.__version__)
 except Exception as e:
     print(e)
 END
@@ -54,7 +55,7 @@ version() {
 }
 
 check_dlr() {
-    disable_metric_collection_command
+    python3 -c "$disable_metric_collection_command"
     get_dlr_version=$(python3 -c "$get_dlr_version_command")
     if [[ "$get_dlr_version" == "$dlr_version" ]]; then
         return 0

--- a/machine-learning/lambda-v2/recipes/com.lambda.DLR-1.6.0.json
+++ b/machine-learning/lambda-v2/recipes/com.lambda.DLR-1.6.0.json
@@ -4,6 +4,11 @@
     "ComponentVersion": "1.6.0",
     "ComponentDescription": "DLR is a compact, common runtime for deep learning models and decision tree models compiled by SageMaker Neo, TVM, or Treelite.",
     "ComponentPublisher": "AWS",
+    "ComponentConfiguration": {
+      "DefaultConfiguration": {
+        "UseInstaller": true
+      }
+    },
     "Manifests": [
       {
         "Platform": {
@@ -12,7 +17,7 @@
         },
         "Lifecycle": {
           "install": {
-            "script": "bash {artifacts:decompressedPath}/installer/installer.sh",
+            "script": "sh {artifacts:decompressedPath}/installer/installer.sh -i {configuration:/UseInstaller}",
             "timeout": "900"
           }
         },


### PR DESCRIPTION
**Issue #, if available:**
* TT No. V410396631

**Description of changes:**
* Added a new `UseInstaller` configuration option in `com.Lambda.DLR` that can be used to disable the install script for platforms that install dependencies at build time or separately.
* Bug fixes and improvements

**Why is this change necessary:**
* ML install scripts fail on platforms like Yocto, where dependencies are bundled in at build time.

**How was this change tested:**
* Tested inside Docker container with Greengrass 2.4.0  by setting `UseInstaller==false` initially, observing  the output `Skipping installation of component dependencies` , setting `UseInstaller==true` and seeing the expected output from installation.

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
