### PR TITLE
refactor: remove default bucket + update EM dependency range

### DIFF
--- a/machine-learning/sagemaker-edge-manager/create_components.py
+++ b/machine-learning/sagemaker-edge-manager/create_components.py
@@ -192,7 +192,6 @@ build_recipes_path = os.path.join(build_dir_path, "recipes")
 shutil.rmtree(build_dir_path, ignore_errors=True, onerror=None)
 
 region = "us-east-1"
-bucket = "ggv2-example-component-artifacts"
 inferenceType = ""
 componentName = ""
 model_releases = (
@@ -207,11 +206,12 @@ parser.add_argument(
     default=region,
     help="Greengrass components will be created in the region.",
 )
-parser.add_argument(
+requiredArgs = parser.add_argument_group("Required arguments")
+requiredArgs.add_argument(
     "--bucket",
     "-b",
-    default=bucket,
-    help="This bucket will be used to store the component artifacts.",
+    required=True,
+    help="S3 bucket used to store the component artifacts.",
 )
 group = parser.add_mutually_exclusive_group()
 group.add_argument(
@@ -230,7 +230,7 @@ group.add_argument(
 args = parser.parse_args()
 
 region = args.region
-bucket = "{}-{}".format(args.bucket, region)
+bucket = args.bucket
 inferenceType = args.inferenceType
 componentName = args.componentName
 

--- a/machine-learning/sagemaker-edge-manager/recipes/com.greengrass.SageMakerEdgeManager.ImageClassification-1.0.0.json
+++ b/machine-learning/sagemaker-edge-manager/recipes/com.greengrass.SageMakerEdgeManager.ImageClassification-1.0.0.json
@@ -26,7 +26,7 @@
     },
     "ComponentDependencies": {
         "aws.greengrass.SageMakerEdgeManager": {
-            "VersionRequirement": ">=1.0.0 <1.1.0",
+            "VersionRequirement": ">=1.0.0",
             "DependencyType": "HARD"
         },
         "com.greengrass.SageMakerEdgeManager.ImageClassification.Model": {

--- a/machine-learning/sagemaker-edge-manager/recipes/com.greengrass.SageMakerEdgeManager.ObjectDetection-1.0.0.json
+++ b/machine-learning/sagemaker-edge-manager/recipes/com.greengrass.SageMakerEdgeManager.ObjectDetection-1.0.0.json
@@ -30,7 +30,7 @@
             "DependencyType": "HARD"
         },
         "aws.greengrass.SageMakerEdgeManager": {
-            "VersionRequirement": ">=1.0.0 <1.1.0",
+            "VersionRequirement": ">=1.0.0",
             "DependencyType": "HARD"
         }
     },


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
- Remove default bucket name in create components script. 
- update sagemaker edge manager dependency component range. 

**Why is this change necessary:**
Keep the examples compatible with latest aws.greengrass.SageMakerEdgeManager component. 
Address https://forums.aws.amazon.com/thread.jspa?threadID=348541&tstart=0
**How was this change tested:**

**Any additional information or context required to review the change:**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
